### PR TITLE
Use comprohension instead of Enum.map

### DIFF
--- a/lib/iptools.ex
+++ b/lib/iptools.ex
@@ -22,12 +22,11 @@ defmodule Iptools do
   @doc """
   Converts a dotted-decimal notation IPv4 string to a list of integers
   """
-  @spec to_list(String.t) :: list()
+  @spec to_list(String.t) :: [integer]
   def to_list(ip) do
     # example input: "10.0.0.1"
-    ip
-    |> String.split(".") # ["10", "0", "0", "1"]
-    |> Enum.map(fn(x) -> String.to_integer(x) end) # [10,0,0,1]
+    segments = String.split(ip, ".") # ["10", "0", "0", "1"]
+    for segment <- segments, do: String.to_integer(segment) # [10,0,0,1]
   end
 
   @doc """


### PR DESCRIPTION
Hi @blackfist,

First I want to say you did a great job with the package.

I updated the `to_list` method to use comprehensions, although the method is very simple I thought using comprehensions makes it even more easy to read instead of using the `Enum.map`.

What do you think?

Again, thanks for the great job on this packeage.

Regards,
Ezequiel
