### PR TITLE
Handle nils in is_ipv4?/1, is_rfc1918?/1, is_reserved?/1

### DIFF
--- a/lib/iptools.ex
+++ b/lib/iptools.ex
@@ -40,7 +40,8 @@ defmodule Iptools do
   @doc """
   Checks if the given string is an IPv4 address in dotted-decimal notation.
   """
-  @spec is_ipv4?(String.t) :: boolean()
+  @spec is_ipv4?(String.t() | nil) :: boolean()
+  def is_ipv4?(nil), do: false
   def is_ipv4?(ip) do
     case Regex.match?(@ipv4_regex, ip) do
       false -> false
@@ -56,7 +57,8 @@ defmodule Iptools do
 
   Returns true if it is an RFC1918 address.
   """
-  @spec is_rfc1918?(String.t) :: boolean()
+  @spec is_rfc1918?(String.t() | nil) :: boolean()
+  def is_rfc1918?(nil), do: false
   def is_rfc1918?(ip) do
     @rfc1918_ranges
     |> Enum.any?(fn({low, high}) -> is_between?(ip, low, high) end)
@@ -70,7 +72,8 @@ defmodule Iptools do
 
   See https://en.wikipedia.org/wiki/Reserved_IP_addresses
   """
-  @spec is_reserved?(String.t) :: boolean()
+  @spec is_reserved?(String.t() | nil) :: boolean()
+  def is_reserved?(nil), do: false
   def is_reserved?(ip) do
     case is_rfc1918?(ip) do
       true -> true

--- a/test/iptools_test.exs
+++ b/test/iptools_test.exs
@@ -19,7 +19,9 @@ defmodule IptoolsTest do
     assert Iptools.is_ipv4?("8.8.8.256") == false
     assert Iptools.is_ipv4?("08.08.08.250") == false
     assert Iptools.is_ipv4?("kevin.com") == false
+    assert Iptools.is_ipv4?(nil) == false
   end
+
   test "identifies RFC1918 ip addresses" do
     assert Iptools.is_rfc1918?("10.10.10.10") == true
     assert Iptools.is_rfc1918?("172.16.10.10") == true
@@ -28,6 +30,7 @@ defmodule IptoolsTest do
     assert Iptools.is_rfc1918?("172.16.0.1") == true
     assert Iptools.is_rfc1918?("172.32.0.1") == false
     assert Iptools.is_rfc1918?("192.30.252.130") == false
+    assert Iptools.is_rfc1918?(nil) == false
   end
 
   test "identifies reserved ip addresses" do
@@ -55,6 +58,7 @@ defmodule IptoolsTest do
     assert Iptools.is_reserved?("203.0.114.1") == false
     assert Iptools.is_reserved?("224.0.0.1") == true
     assert Iptools.is_reserved?("255.255.255.255") == true
+    assert Iptools.is_reserved?(nil) == false
   end
 
   test "converts dotted decimal ips to integers" do


### PR DESCRIPTION
a `nil` is not ipv4, or rfc1918, or reserved, so return false when nil is passed.

Also add tests for the above.