### PR TITLE
Fix bug in IPv4 detection regex

### DIFF
--- a/lib/iptools.ex
+++ b/lib/iptools.ex
@@ -51,6 +51,10 @@ defmodule Iptools do
     |> Enum.map(fn s -> String.to_integer(s) end)
   end
 
+  @doc deprecated: "Replaced by `to_int_list/1`"
+  @spec to_list(String.t()) :: [integer()]
+  def to_list(ip), do: to_int_list(ip)
+
   @doc """
   Checks if the given string is an IPv4 address in dotted-decimal notation.
   """

--- a/lib/iptools.ex
+++ b/lib/iptools.ex
@@ -33,7 +33,7 @@ defmodule Iptools do
   Example input: `"10.0.0.1"`
   Example output: `["10", "0", "0", "1"]`
   """
-  @spec to_str_list(String.t) :: [integer]
+  @spec to_str_list(String.t()) :: [String.t()]
   def to_str_list(ip) do
     String.split(ip, ".") # ["10", "0", "0", "1"]
   end
@@ -44,7 +44,7 @@ defmodule Iptools do
   Example input: `"10.0.0.1"`
   Example output: `[10, 0, 0, 1]`
   """
-  @spec to_int_list(String.t()) :: [String.t()]
+  @spec to_int_list(String.t()) :: [integer()]
   def to_int_list(ip) do
     ip
     |> to_str_list()

--- a/test/iptools_test.exs
+++ b/test/iptools_test.exs
@@ -3,7 +3,11 @@ defmodule IptoolsTest do
   doctest Iptools
 
   test "converts an IPv4 dotted-decimal to a list of integers" do
-    assert Iptools.to_list("10.0.0.1") == [10, 0, 0, 1]
+    assert Iptools.to_int_list("10.0.0.1") == [10, 0, 0, 1]
+  end
+
+  test "converts an IPv4 dotted-decimal to a list of strings" do
+    assert Iptools.to_str_list("10.0.0.1") == ["10", "0", "0", "1"]
   end
 
   test "identifies an IPv4 dotted-decimal ip address" do
@@ -20,6 +24,17 @@ defmodule IptoolsTest do
     assert Iptools.is_ipv4?("08.08.08.250") == false
     assert Iptools.is_ipv4?("kevin.com") == false
     assert Iptools.is_ipv4?(nil) == false
+    assert Iptools.is_ipv4?("127.0.0.1") == true
+    assert Iptools.is_ipv4?("127.1.1.1") == true
+    assert Iptools.is_ipv4?("192.168.1.1") == true
+    assert Iptools.is_ipv4?("1.0.0.1") == true
+    assert Iptools.is_ipv4?("1.1.1") == false
+    assert Iptools.is_ipv4?("1.1.1.1.1") == false
+    assert Iptools.is_ipv4?("1.2.a.3") == false
+    assert Iptools.is_ipv4?("314.23.3.4") == false
+    assert Iptools.is_ipv4?("1.1.1.299") == false
+    assert Iptools.is_ipv4?("...") == false
+    assert Iptools.is_ipv4?("2..4.5") == false
   end
 
   test "identifies RFC1918 ip addresses" do
@@ -31,6 +46,7 @@ defmodule IptoolsTest do
     assert Iptools.is_rfc1918?("172.32.0.1") == false
     assert Iptools.is_rfc1918?("192.30.252.130") == false
     assert Iptools.is_rfc1918?(nil) == false
+    assert Iptools.is_rfc1918?("127.0.0.1") == false
   end
 
   test "identifies reserved ip addresses" do

--- a/test/iptools_test.exs
+++ b/test/iptools_test.exs
@@ -10,6 +10,11 @@ defmodule IptoolsTest do
     assert Iptools.to_str_list("10.0.0.1") == ["10", "0", "0", "1"]
   end
 
+  test "#to_list/1 returns same output as #to_int_list/1" do
+    assert Iptools.to_list("10.0.0.1") == [10, 0, 0, 1]
+    assert Iptools.to_list("10.0.0.1") == Iptools.to_int_list("10.0.0.1")
+  end
+
   test "identifies an IPv4 dotted-decimal ip address" do
     assert Iptools.is_ipv4?("8.8.8.8") == true
     assert Iptools.is_ipv4?("-8.8.8.8") == false


### PR DESCRIPTION
The previous regex did not identify IP addresses with a 0 segment as
valid IPv4.  For example, `Iptools.is_ipv4?("127.0.0.1")` would return
`false`.

After fixing the regex, addresses with leading zeroes were now allowed,
for example "08.08.08.08".  To handle this corner case, we add checking
that will catch this and return false as we did before.

Also adds more test cases to really hone behavior.

Fixes #13

NOTE: #10 and possibly #12 should probably be merged prior to this to 
avoid merge conflicts